### PR TITLE
Ignore whitespaces when decoding cookie's content

### DIFF
--- a/lib/plug_rails_cookie_session_store/message_verifier.ex
+++ b/lib/plug_rails_cookie_session_store/message_verifier.ex
@@ -11,15 +11,11 @@ defmodule PlugRailsCookieSessionStore.MessageVerifier do
   Decodes and verifies the encoded binary was not tampared with.
   """
   def verify(binary, secret) when is_binary(binary) and is_binary(secret) do
-    case String.split(binary, "--") do
-      [content, digest] when content != "" and digest != "" ->
-        if Plug.Crypto.secure_compare(digest(secret, content), digest) do
-          {:ok, Base.decode64!(content)}
-        else
-          :error
-        end
-      _ ->
-        :error
+    with [content, digest] when content != "" and digest != "" <- String.split(binary, "--"),
+         true <- Plug.Crypto.secure_compare(digest(secret, content), digest) do
+      {:ok, Base.decode64!(content, ignore: :whitespace)}
+    else
+      _ -> :error
     end
   end
 


### PR DESCRIPTION
Our Rails 4 application encodes cookie with Marshal and for some reason its encoded value consists of newlines (`\n`)
By default `Base.decode64/1` throws an ArgumentError
```elixir
iex> content = "BAh7BkkiD3Nlc3Npb25faWQGOgZFVEkiKTk5ZDQ3YzdiLTdlODItNGUxZS1h\nYTMyLWE4MjIwOWVhNDA5ZQY7AFQ=\n"
iex> Base.decode64!(content)
** (ArgumentError) non-alphabet digit found: "\n" (byte 10)
    (elixir 1.11.0) lib/base.ex:1002: Base.dec64/1
    (elixir 1.11.0) lib/base.ex:1018: Base."-do_decode64/2-lbc$^0/2-0-"/2
    (elixir 1.11.0) lib/base.ex:1012: Base.do_decode64/2
```

That issue is easily fixed with passing `ignore: :whitespace` option to `Base.decode64!`
```elixir
iex> Base.decode64!(content, ignore: :whitespace) |> ExMarshal.decode()
%{"session_id" => "99d47c7b-7e82-4e1e-aa32-a82209ea409e"}
```

----
Plus as a bonus I use `with` to avoid nested condition