### PR TITLE
:crypto.hmac has been deprecated and removed in OTP 24 

### DIFF
--- a/lib/plug_rails_cookie_session_store/message_verifier.ex
+++ b/lib/plug_rails_cookie_session_store/message_verifier.ex
@@ -31,7 +31,14 @@ defmodule PlugRailsCookieSessionStore.MessageVerifier do
     encoded <> "--" <> digest(secret, encoded)
   end
 
-  defp digest(secret, data) do
-    :crypto.hmac(:sha, secret, data) |> Base.encode16(case: :lower)
+  # TODO: remove when we require OTP 22.1
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp digest(secret, data) do
+      :crypto.mac(:hmac, :sha, secret, data) |> Base.encode16(case: :lower)
+    end
+  else
+    defp digest(secret, data) do
+      :crypto.hmac(:sha, secret, data) |> Base.encode16(case: :lower)
+    end
   end
 end


### PR DESCRIPTION
This commit applies the same fix as in https://github.com/elixir-plug/plug_crypto/blob/8c1f9271c9a0fb241b1cc970608187246d88d29d/lib/plug/crypto/key_generator.ex\#L95